### PR TITLE
tesnors support primitive types (#14)

### DIFF
--- a/nanotorch/tensor/tensor.py
+++ b/nanotorch/tensor/tensor.py
@@ -33,6 +33,8 @@ class Tensor(np.ndarray):
                         [2],
                         [3]])
         """
+
+        if isinstance(input, (int, float)): input = np.array([input,])
         
         if not isinstance(input, (Tensor, list, tuple, np.ndarray)): 
             raise ValueError(f"the 'input' attributes must be list, tuple, numpy.ndarray. But '{input.__class__.__name__}' is given") 


### PR DESCRIPTION
This issue #14 is now fixed

```python
if isinstance(input, (int, float)): input = np.array([input,])
```
we just add an if statement is `input` is an `int` or `float`. Then, convert it to numpy array. 